### PR TITLE
Added sticky table header

### DIFF
--- a/components/support-table.js
+++ b/components/support-table.js
@@ -43,24 +43,24 @@ export default function SupportTable() {
   return(
     <div className="w-full overflow-x-scroll md:overflow-x-auto py-4">
       <table className="support w-full mx-auto text-xs 2xl:text-base">
-        <thead className="font-display">
+        <thead className="font-display relative z-50">
           <tr>
-            <th className="font-normal border-y border-slate-400 p-2 p-2 min-w-[160px] max-w-[240px] text-left">
+            <th className="bg-white font-normal p-2 p-2 min-w-[160px] max-w-[240px] text-left">
               <WalletIcon className="w-4 h-4 md:w-6 md:h-6 block md:inline" aria-hidden="true" /> Name
             </th>
-            <th className="font-normal border-y border-slate-400 p-2 min-w-[160px] max-w-[180px]">
+            <th className="bg-white font-normal p-2 min-w-[160px] max-w-[180px]">
               <SendIcon className="w-4 h-4 md:w-6 md:h-6 mx-auto md:inline" aria-hidden="true" /> Send to Bech32m
             </th>
-            <th className="font-normal border-y border-slate-400 p-2 p-2 min-w-[160px] max-w-[180px]">
+            <th className="bg-white font-normal p-2 p-2 min-w-[160px] max-w-[180px]">
               <ReceiveIcon className="w-4 h-4 md:w-6 md:h-6 mx-auto md:inline" aria-hidden="true" /> Receive to P2TR
             </th>
-            <th className="font-normal border-y border-slate-400 p-2 min-w-[80px] max-w-[100px]">
+            <th className="bg-white font-normal p-2 min-w-[80px] max-w-[100px]">
               <AlertIcon className="w-4 h-4 md:w-6 md:h-6 mx-auto md:inline" aria-hidden="true" /> Issue Link
             </th>
-            <th className="font-normal border-y border-slate-400 p-2 min-w-[148px] max-w-[200px]">
+            <th className="bg-white font-normal p-2 min-w-[148px] max-w-[200px]">
               <UserIcon className="w-4 h-4 md:w-6 md:h-6 mx-auto md:inline" aria-hidden="true" /> Credit
             </th>
-            <th className="font-normal border-y border-slate-400 p-2 min-w-[148px]">
+            <th className="bg-white font-normal p-2 min-w-[148px]">
               <InfoIcon className="w-4 h-4 md:w-6 md:h-6 mx-auto md:inline" aria-hidden="true" /> Notes
             </th>
           </tr>

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,6 +32,20 @@ export default function Home() {
   const checkScrollPosition = (e) => {
     if(window.scrollY > 100) changeMenuStyle(false)
     else changeMenuStyle(true)
+    
+    let supportTable = document.querySelector('#support-container table')
+    let supportTableHead = supportTable.querySelector('thead')
+    let header = document.getElementById('header')
+    
+    if(window.scrollY > (supportTable.offsetTop - header.scrollHeight) && window.scrollY < (supportTable.offsetTop + supportTable.scrollHeight)) {
+      let diff = window.scrollY - supportTable.offsetTop
+      
+      supportTableHead.style.top = (diff + header.scrollHeight) + 'px'
+      
+    }
+    else {
+      supportTableHead.style.top = '0'
+    }
   }
 
   const scrollTo = (e) => {
@@ -215,7 +229,7 @@ export default function Home() {
             The state of taproot support
           </h2>
           
-          <div className="w-full">
+          <div className="w-full" id="support-container">
             <SupportTable />
           </div>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -331,7 +331,7 @@ export default function Home() {
             The state of taproot support
           </h2>
           
-          <div className="w-full">
+          <div id="support-container" className="w-full">
             <SupportTable />
           </div>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -96,8 +96,16 @@ h4 {
     @apply translate-y-[-100%] opacity-0 pointer-events-none xl:translate-y-0 xl:opacity-100 xl:pointer-events-auto;
 }
 
+table.support {
+    @apply border-x border-slate-400;
+}
+
 table.support td {
     @apply border-y border-slate-400 p-2 text-center;
+}
+
+table.support th {
+    @apply border-y border-slate-400;
 }
 
 table.support td:first-child, table.support td:last-child  {


### PR DESCRIPTION
I added a sticky header to the table. Due to the fact that the table can scroll horizontally, it's not easy to do this with things like `position: sticky` because the horizontal scroll interferes with it. I have done a hacky little scroll header that basically just nudges the header down relatively everytime the page scrolls (with a few other conditions, too). I want to make sure this performs well before we merge it.