### PR TITLE
add correct URL for wasabi wallet

### DIFF
--- a/data/formatted/support.json
+++ b/data/formatted/support.json
@@ -679,7 +679,7 @@
   {
     "wallet": {
       "name": "Wasabi Wallet",
-      "uri": "https://wasabiwallet.us/"
+      "uri": "https://wasabiwallet.io/"
     },
     "send_to_bech32": {
       "status": "yes"


### PR DESCRIPTION
`https://wasabiwallet.us` was actually a scam website