### PR TITLE
Update Strike to supports sending to bech32m

### DIFF
--- a/data/formatted/support.json
+++ b/data/formatted/support.json
@@ -181,7 +181,7 @@
       "status": "yes"
     },
     "send_to_bech32m": {
-      "status": "no"
+      "status": "yes"
     },
     "receive_to_p2tr": {
       "status": "no"


### PR DESCRIPTION
According to Rockstar, Strike now supports sending to bech32m addresses. It would be great to confirm this, if one of you has a Strike account.