### PR TITLE
Limit meta description for better SEO

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -123,9 +123,7 @@ export default function Home() {
     <div>
       <Head>
         <title>When Taproot? | Bitcoin Bech32m Adoption Tracking</title>
-        <meta name="description" content="Taproot offers bitcoin users and businesses big benefits. But to unlock them, first we need wallet
-                interoperability. Taproot requires Bech32m, a new address format, which is slightly different from Bech32.
-                This means that Taproot adoption will only take off when wallets support sending to this new format." />
+        <meta name="description" content="Unlock the benefits of Taproot for bitcoin users and business with wallet interoperability. Support for sending to Bech32m addresses is key for Taproot adoption." />
         <meta property="og:image" content="/when-taproot-poster.png" />
         <meta property="og:image:width" content="1920" />
         <meta property="og:image:height" content="1080" />


### PR DESCRIPTION
The new meta description targets keywords Taproot, Bech32m and Send. Google otherwise cuts off meta descriptions that exceed 1000px rendered. Perhaps "support" is a better keyword here than "interoperability"

## After

![image](https://user-images.githubusercontent.com/8525467/214986532-360a4058-54e7-4b7c-823c-7a28f902ab88.png)

## Before

![image](https://user-images.githubusercontent.com/8525467/214986658-b5b98bf5-45db-46c2-9b82-e6b8f7a95be0.png)

